### PR TITLE
Fix compiler errors with Mini Player in Projects without UDON + Surface Shader Texture Availability check

### DIFF
--- a/AudioLink/Scripts/AudioLinkMiniPlayer.cs
+++ b/AudioLink/Scripts/AudioLinkMiniPlayer.cs
@@ -1,4 +1,4 @@
-﻿
+﻿#if UDON
 using System;
 using UdonSharp;
 using UnityEngine;
@@ -29,7 +29,7 @@ namespace AudioLinkPrefab
 
         [Tooltip("Automatically loop track when finished")]
         public bool loop = false;
-        
+
         float retryTimeout = 6;
         float syncFrequency = 5;
         float syncThreshold = 1;
@@ -519,3 +519,4 @@ namespace AudioLinkPrefab
         }
     }
 }
+#endif

--- a/AudioLink/Scripts/AudioLinkMiniPlayerController.cs
+++ b/AudioLink/Scripts/AudioLinkMiniPlayerController.cs
@@ -1,4 +1,4 @@
-﻿
+﻿#if UDON
 using UdonSharp;
 using UnityEngine;
 using UnityEngine.UI;
@@ -256,7 +256,7 @@ namespace AudioLinkPrefab
                         SetPlaceholderText("");
                         SetStatusText(MakeOwnerMessage());
                     }
-                    
+
                 }
             }
 
@@ -387,3 +387,4 @@ namespace AudioLinkPrefab
     }
 #endif
 }
+#endif

--- a/AudioLink/Shaders/AudioLink.cginc
+++ b/AudioLink/Shaders/AudioLink.cginc
@@ -60,12 +60,16 @@ float4 AudioLinkLerp(float2 xy) { return lerp( AudioLinkData(xy), AudioLinkData(
 // Same as AudioLinkLerp but properly handles multiline reading.
 float4 AudioLinkLerpMultiline(float2 xy) { return lerp( AudioLinkDataMultiline(xy), AudioLinkDataMultiline(xy+float2(1,0)), frac( xy.x ) ); }
 
-//Tests to see if Audio Link texture is available, I think this only works on VertFrag shaders. Will need another method for Surface Shaders?
+//Tests to see if Audio Link texture is available
 bool AudioLinkIsAvailableNonSurface()
 {
-    int width, height;
-    _AudioTexture.GetDimensions(width, height);
-    return width > 16;
+    #if !defined(AUDIOLINK_STANDARD_INDEXING)
+        int width, height;
+        _AudioTexture.GetDimensions(width, height);
+        return width > 16;
+    #else
+        return _AudioTexture_TexelSize.z > 16;
+    #endif
 }
 
 // Decompress a RGBA FP16 into a really big number, this is used in some sections of the info block.


### PR DESCRIPTION
- if defd mini player so it only tries to compile if UDON is available (missed this earlier)
- added support for checking if audio texture is available for surface shaders (I think)