### PR TITLE
include PiMaker/VRChatUnityThings into compatible tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The per-frequency audio amplitude data is first read briefly into Udon using Uni
 - [VR Stage Lighting](https://github.com/AcChosen/VR-Stage-Lighting) by AcChosen
 - [Poiyomi Shader](https://poiyomi.com/) by Poiyomi
 - [orels1 AudioLink Shader](https://github.com/orels1/orels1-AudioLink-Shader) by orels1
+- [VRC Things](https://github.com/PiMaker/VRChatUnityThings) by \_pi\_
 
 ## Thank you
 - phosphenolic for the math wizardry, conceptual programming, debugging, design help and emotional support!!!


### PR DESCRIPTION
Hi!

I've made two of my assets AudioLink compatible: An Aurora shader that lights up to music and uses the synced time to show everyone the same visuals, and a tool to bake blendshapes into static meshes and have them react to AudioLink via a shader (intended for instancing many speakers with little overhead on a big stage for example). My README mentions right at the top which assets are compatible, license is CC BY-NC-SA. There might be more in the future :)

I'd be honored to have them mentioned on the official repo!

PS: Feel free to make the name more descriptive, that's just what I called my repo - and sorry for the hunk at the end, GitHub's online editor is weird