### PR TITLE
Don't sample the GrabPass in CRT for chronotensity

### DIFF
--- a/AudioLink/Shaders/AudioLink.shader
+++ b/AudioLink/Shaders/AudioLink.shader
@@ -1012,7 +1012,8 @@ Shader "AudioLink/Internal/AudioLink"
                 {
                     // For pixel 16, we are actually making something that accelerates forward.
                     // This is called ALPASS_CHRONOTENSITY
-                    uint Value = AudioLinkDecodeDataAsUInt( coordinateGlobal.xy );
+                    uint4 rpx = AudioLinkGetSelfPixelData(coordinateGlobal.xy);
+                    uint Value = rpx.r + rpx.g * 1024 + rpx.b * 1048576 + rpx.a * 1073741824;
                     
                     float ComparingValue = (coordinateLocal.x & 1) ? 
                         AudioLinkGetSelfPixelData(ALPASS_FILTEREDAUDIOLINK + uint2(4, coordinateLocal.y)) :
@@ -1021,7 +1022,7 @@ Shader "AudioLink/Internal/AudioLink"
                     //Get a heavily filtered value to compare against.
                     float FilteredAudioLinkValue = AudioLinkGetSelfPixelData(ALPASS_FILTEREDAUDIOLINK + uint2( 0, coordinateLocal.y ) );
                     
-                    float DifferentialValue = AudioLinkBase - FilteredAudioLinkValue;
+                    float DifferentialValue = ComparingValue - FilteredAudioLinkValue;
 
                     float ValueDiff;
 


### PR DESCRIPTION
Chronotensity pass was using AudioLinkDecodeAsUInt which samples the GrabPass. Instead, it should sample the last frame of the CRT directly, since there is a delta of one frame between those 2 methods. This in turn caused ping-ponging values even when there is no audio (I tested with 0 gain). This fixes flickering with chronotensity.

Also, Charles calculates a value for comparison in that pass dependent on if you want to use filtered output or not, but then he never uses this value. I put the value to use where I believe it was intended, and it looks much better to me.