### PR TITLE
Fix bug: ALPASS_FILTEREDAUDIOLINK + vec2(7, ...) was always zero

### DIFF
--- a/AudioLink/Shaders/AudioLink.shader
+++ b/AudioLink/Shaders/AudioLink.shader
@@ -1010,10 +1010,8 @@ Shader "AudioLink/Internal/AudioLink"
                 }
                 else if( coordinateLocal.x >= 16 &&  coordinateLocal.x <= 22 )
                 {
-                    // For pixel 16, we are actually making something that accelerates forward.
-                    // This is called ALPASS_CHRONOTENSITY
+                    // This section is for ALPASS_CHRONOTENSITY
                     uint4 rpx = AudioLinkGetSelfPixelData(coordinateGlobal.xy);
-                    uint Value = rpx.r + rpx.g * 1024 + rpx.b * 1048576 + rpx.a * 1073741824;
                     
                     float ComparingValue = (coordinateLocal.x & 1) ? 
                         AudioLinkGetSelfPixelData(ALPASS_FILTEREDAUDIOLINK + uint2(4, coordinateLocal.y)) :
@@ -1038,19 +1036,14 @@ Shader "AudioLink/Internal/AudioLink"
                     }
                     else if( mode == 2 )
                     {
-                        if( DifferentialValue < 0 )
-                            ValueDiff = .1;
-                        else
-                            ValueDiff = 0;
+                        ValueDiff = DifferentialValue < 0? .1 : -.1;
                     }
                     else
                     {
-                        if( DifferentialValue < 0 )
-                            ValueDiff = .1;
-                        else
-                            ValueDiff = -.1;
+                        ValueDiff = DifferentialValue < 0? .1 : -.1;
                     }
                     
+                    uint Value = rpx.r + rpx.g * 1024 + rpx.b * 1048576 + rpx.a * 1073741824;
                     Value += ValueDiff * 32768;
 
                     return float4(

--- a/AudioLink/Shaders/AudioLink.shader
+++ b/AudioLink/Shaders/AudioLink.shader
@@ -1008,7 +1008,7 @@ Shader "AudioLink/Internal/AudioLink"
                     float4 Previous = AudioLinkGetSelfPixelData(ALPASS_FILTEREDAUDIOLINK + int2(coordinateLocal.x, coordinateLocal.y));
                     return lerp( AudioLinkBase, Previous, pow( .99, coordinateLocal.x+1 ) );
                 }
-                else if( coordinateLocal.x >= 16 &&  coordinateLocal.x <= 22 )
+                else if( coordinateLocal.x >= 16 &&  coordinateLocal.x < 24 )
                 {
                     // This section is for ALPASS_CHRONOTENSITY
                     uint4 rpx = AudioLinkGetSelfPixelData(coordinateGlobal.xy);

--- a/Docs/README.md
+++ b/Docs/README.md
@@ -342,7 +342,7 @@ You must read this using `AudioLinkDecodeDataAsUInt( ALPASS_CHRONOTENSITY + offs
 | 4 | Fixed speed increase when the band is dark. Stationary when light. |
 | 5 | Same as above but uses `ALPASS_FILTERAUDIOLINK` instead of `ALPASS_AUDIOLINK` |
 | 6 | Fixed speed increase when the band is dark. Fixed speed decrease when light. |
-| 7 | Same as above but uses `ALPASS_FILTERAUDIOLINK` instead of `ALPASS_AUDIOLINK`. Potential bug: Currently always zero. |
+| 7 | Same as above but uses `ALPASS_FILTERAUDIOLINK` instead of `ALPASS_AUDIOLINK`. |
 
 You can combine these to create new motion.
 For example, to get "Fixed increase when the band is light" you could subtract a uint sample with `offset.x = 6` from a uint sample with `offset.x = 4`.


### PR DESCRIPTION
Was an off-by-one error. 
`coordinateLocal.x <= 22` -> `coordinateLocal.x < 24`