### PR TITLE
Add header guard to AudioLink.cginc

### DIFF
--- a/AudioLink/Shaders/AudioLink.cginc
+++ b/AudioLink/Shaders/AudioLink.cginc
@@ -1,3 +1,6 @@
+#ifndef AUDIOLINK_CGINC_INCLUDED
+#define AUDIOLINK_CGINC_INCLUDED
+
 // Map of where features in AudioLink are.
 #define ALPASS_DFT                      uint2(0,4)  //Size: 128, 2
 #define ALPASS_WAVEFORM                 uint2(0,6)  //Size: 128, 16
@@ -222,3 +225,5 @@ float AudioLinkGetChronoTimeInterval(uint index, uint band, float speed, float i
 {
     return AudioLinkGetChronoTimeNormalized(index, band, speed) * interval;
 }
+
+#endif


### PR DESCRIPTION
This is a public facing API, and as such should have a header guard, so that modular shaders can include the file wherever necessary without stepping on each other's toes.

As a practical example, adding AudioLink support to LTCGI usually breaks shaders when both are used in combination on one material, since `LTCGI.cginc` also includes `AudioLink.cginc`.