### PR TITLE
Update instance owner use to the non-broken one.

### DIFF
--- a/AudioLink/Scripts/AudioLink.cs
+++ b/AudioLink/Scripts/AudioLink.cs
@@ -217,7 +217,7 @@ public class AudioLink : UdonSharpBehaviour
             audioMaterial.SetVector("_PlayerCountAndData", new Vector4(
                 VRCPlayerApi.GetPlayerCount(),
                 Networking.IsMaster?1.0f:0.0f,
-                Networking.IsInstanceOwner?1.0f:0.0f,
+                Networking.LocalPlayer.isInstanceOwner?1.0f:0.0f,
                 0 ) );
 
             #else


### PR DESCRIPTION
Switch from Networking.IsInstanceOwner to Networking.LocalPlayer.isInstanceOwner because the static method is known to be broken.
Addresses #161 