### PR TITLE
Fixed NullReferenceException in LinkAll.

### DIFF
--- a/AudioLink/Scripts/AudioLink.cs
+++ b/AudioLink/Scripts/AudioLink.cs
@@ -406,6 +406,7 @@ public class AudioLink : UdonSharpBehaviour
             UdonBehaviour[] allBehaviours = UnityEngine.Object.FindObjectsOfType<UdonBehaviour>();
             foreach (UdonBehaviour behaviour in allBehaviours)
             {
+                if (!behaviour.programSource) continue;
                 var program = behaviour.programSource.SerializedProgramAsset.RetrieveProgram();
                 ImmutableArray<string> exportedSymbolNames = program.SymbolTable.GetExportedSymbols();
                 foreach (string exportedSymbolName in exportedSymbolNames)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The per-frequency audio amplitude data is first read briefly into Udon using Uni
 
 ### Requirements
 - [VRChat SDK3](https://vrchat.com/home/download) for worlds (Udon)
-- [UdonSharp](https://github.com/MerlinVR/UdonSharp/releases/latest)
+- [UdonSharp](https://github.com/vrchat-community/UdonSharp/releases/latest)
 - [CyanEmu](https://github.com/CyanLaser/CyanEmu/releases/latest) (optional but highly recommended)
 - The latest release: https://github.com/llealloo/vrc-udon-audio-link/releases/latest
 


### PR DESCRIPTION
Fixed a NullReferenceException that would occur if you have an empty UdonBehaviour when trying to link all sound reactive objects.