### PR TITLE
cleanup warning

### DIFF
--- a/AudioLink/Shaders/AudioLink.shader
+++ b/AudioLink/Shaders/AudioLink.shader
@@ -323,7 +323,7 @@ Shader "AudioLink/Internal/AudioLink"
                     // Slide pixels (coordinateLocal.x > 0)
                     float4 lastvalTiming = AudioLinkGetSelfPixelData(ALPASS_GENERALVU + int2(4, 1)); // Timing for 4-band, move at 90 Hz.
                     lastvalTiming.x += unity_DeltaTime.x * AUDIOLINK_4BAND_TARGET_RATE;
-                    int framesToRoll = floor( lastvalTiming.x );
+                    uint framesToRoll = floor( lastvalTiming.x );
 
                     if( framesToRoll == 0 )
                     {


### PR DESCRIPTION
Before this change, there used to be this warning:
`Shader warning in 'AudioLink/Internal/AudioLink': signed/unsigned mismatch, unsigned assumed at line 334`

Note to reviewer: Please double check my assumption that `lastvalTiming >= 0`.
I'm not entirely sure of the values at `ALPASS_GENERALVU + int2(4, 1)`