### PR TITLE
Cleanup unused variable

### DIFF
--- a/AudioLink/Shaders/AudioLink.shader
+++ b/AudioLink/Shaders/AudioLink.shader
@@ -98,7 +98,7 @@ Shader "AudioLink/Internal/AudioLink"
             uniform float _AutogainDerate;
 
             // Set by Udon
-            uniform float4 _AdvancedTimeProps, _AdvancedTimeProps2, _AdvancedTimeProps3;
+            uniform float4 _AdvancedTimeProps, _AdvancedTimeProps2;
             uniform float4 _VersionNumberAndFPSProperty;
             uniform float4 _PlayerCountAndData;
 


### PR DESCRIPTION
This is used neither in CSharp or the shader.
Seems like CN's additional stuff fit into `_AdvancedTimeProps2` without needing an additional variable.