### PR TITLE
Fix updated Unity 2021 namespace compile error

### DIFF
--- a/AudioLink/Scripts/AudioLinkAutoConfigurator.cs
+++ b/AudioLink/Scripts/AudioLinkAutoConfigurator.cs
@@ -1,8 +1,12 @@
 ﻿#if UNITY_EDITOR
   using System.IO;
   using UnityEditor;
-  using UnityEditor.Experimental.SceneManagement;
   using UnityEngine;
+#if UNITY_2021_1_OR_NEWER
+  using UnityEditor.SceneManagement;
+#else
+  using UnityEditor.Experimental.SceneManagement;
+#endif
 #if UDON
   using UdonSharp;
   using UdonSharpEditor;


### PR DESCRIPTION
UnityEditor.Experimental.SceneManagement becomes UnityEditor.SceneManagement in Unity 2021.