### PR TITLE
AudioLink Shader Compatability Utility

### DIFF
--- a/Packages/com.llealloo.audiolink/Editor/Scripts/AudioLinkImportFix.cs
+++ b/Packages/com.llealloo.audiolink/Editor/Scripts/AudioLinkImportFix.cs
@@ -25,6 +25,7 @@ namespace VRCAudioLink.Editor
                 {
                     ReimportPackage();
                     File.WriteAllText(canaryFilePath, audioLinkReimportedKey);
+                    AudioLinkShaderCompatabilityUtility.UpgradeShaders();
                 }
             }
         }

--- a/Packages/com.llealloo.audiolink/Editor/Scripts/AudioLinkShaderCompatabilityUtility.cs
+++ b/Packages/com.llealloo.audiolink/Editor/Scripts/AudioLinkShaderCompatabilityUtility.cs
@@ -68,7 +68,7 @@ namespace VRCAudioLink.Editor
             string[] files = Directory.GetFiles(path);
             foreach (string file in files)
             {
-                if (file.EndsWith(".cginc"))
+                if (file.EndsWith(".cginc") || file.EndsWith(".hlsl"))
                 {
                     cgincList.Add(file);
                 }

--- a/Packages/com.llealloo.audiolink/Editor/Scripts/AudioLinkShaderCompatabilityUtility.cs
+++ b/Packages/com.llealloo.audiolink/Editor/Scripts/AudioLinkShaderCompatabilityUtility.cs
@@ -9,17 +9,17 @@ namespace VRCAudioLink.Editor
     {
         private const string OldPath = "Assets/AudioLink/Shaders/AudioLink.cginc";
         private const string NewPath = "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc";
-        private const string MenuItemPath = "AudioLink Menu/Run AudioLink Shader Compatibility Utility";
+        private const string MenuItemPath = "AudioLink/Upgrade AudioLink shaders";
 
         private const string DialogText =
             "Do you want to check all shaders in this project for AudioLink 0.3.x compatibility and update them if necessary? This is useful for upgrading projects using AudioLink 0.2.x or below.?"
             + "\n" + "\n" +
             "If you choose 'Go Ahead', shader files in this project which include 'AudioLink.cginc' will be edited to use the new path introduced by AudioLink 0.3.x. Shaders which already use the new path will be unaffected. You should make a backup before proceeding."
             + "\n" + "\n" +
-            "(You can always run this utility manually via the " + MenuItemPath + "menu command)";
+            "(You can always run this utility manually via the " + MenuItemPath + " menu command)";
 
-        private const string DialogTitle = "I Made a Backup, Go Ahead! ";
-        private const string DialogOkButton = "AudioLink Shader Compatibility Utility";
+        private const string DialogTitle = "AudioLink Shader Compatibility Utility";
+        private const string DialogOkButton = "I Made a Backup, Go Ahead!";
         private const string DialogCancelButton = "No Thanks";
 
 

--- a/Packages/com.llealloo.audiolink/Editor/Scripts/AudioLinkShaderCompatabilityUtility.cs
+++ b/Packages/com.llealloo.audiolink/Editor/Scripts/AudioLinkShaderCompatabilityUtility.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+namespace VRCAudioLink.Editor
+{
+    public class AudioLinkShaderCompatabilityUtility
+    {
+        private const string OldPath = "Assets/AudioLink/Shaders/AudioLink.cginc";
+        private const string NewPath = "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc";
+        private const string MenuItemPath = "AudioLink Menu/Run AudioLink Shader Compatibility Utility";
+
+
+        [MenuItem(MenuItemPath)]
+        public static void UpgradeShaders()
+        {
+            if (EditorUtility.DisplayDialog("AudioLink Shader Compatibility Utility",
+                    "Do you want to check all shaders in this project for AudioLink 0.3.x compatibility and update them if necessary? This is useful for upgrading projects using AudioLink 0.2.x or below.?"
+                    + Environment.NewLine + Environment.NewLine +
+                    "If you choose 'Go Ahead', shader files in this project which include 'AudioLink.cginc' will be edited to use the new path introduced by AudioLink 0.3.x. Shaders which already use the new path will be unaffected. You should make a backup before proceeding."
+                    + Environment.NewLine + Environment.NewLine +
+                    "(You can always run this utility manually via the " + MenuItemPath + "menu command)"
+                    ,
+                    "I Made a Backup, Go Ahead! ", "No Thanks"))
+            {
+                UpgradeShaderFiles();
+                UpgradeCgincFiles();
+            }
+        }
+
+        private static void UpgradeShaderFiles()
+        {
+            ShaderInfo[] shaders = ShaderUtil.GetAllShaderInfo();
+
+            foreach (ShaderInfo shaderinfo in shaders)
+            {
+                Shader shader = Shader.Find(shaderinfo.name);
+                if (AssetDatabase.GetAssetPath(shader).StartsWith("Assets") ||
+                    AssetDatabase.GetAssetPath(shader).StartsWith("Packages"))
+                {
+                    string path = AssetDatabase.GetAssetPath(shader);
+                    ReplaceInFile(path);
+                }
+            }
+        }
+
+        private static void UpgradeCgincFiles()
+        {
+            List<string> cgincs = FindCgincFiles(Application.dataPath);
+            foreach (string cginc in cgincs)
+            {
+                ReplaceInFile(cginc);
+            }
+        }
+
+        private static List<string> FindCgincFiles(string path)
+        {
+            List<string> cgincList = new List<string>();
+
+            string[] files = Directory.GetFiles(path);
+            foreach (string file in files)
+            {
+                if (file.EndsWith(".cginc"))
+                {
+                    cgincList.Add(file);
+                }
+            }
+
+            string[] folders = Directory.GetDirectories(path);
+            foreach (string folder in folders)
+            {
+                List<string> cgincs = FindCgincFiles(folder);
+                foreach (string cginc in cgincs)
+                {
+                    cgincList.Add(cginc);
+                }
+            }
+
+            return cgincList;
+        }
+
+        private static void ReplaceInFile(string path)
+        {
+            string shaderSource = File.ReadAllText(path);
+            shaderSource = shaderSource.Replace(OldPath, NewPath);
+            File.WriteAllText(path, shaderSource);
+        }
+    }
+}

--- a/Packages/com.llealloo.audiolink/Editor/Scripts/AudioLinkShaderCompatabilityUtility.cs
+++ b/Packages/com.llealloo.audiolink/Editor/Scripts/AudioLinkShaderCompatabilityUtility.cs
@@ -30,6 +30,7 @@ namespace VRCAudioLink.Editor
             {
                 UpgradeShaderFiles();
                 UpgradeCgincFiles();
+                AssetDatabase.Refresh();
             }
         }
 

--- a/Packages/com.llealloo.audiolink/Editor/Scripts/AudioLinkShaderCompatabilityUtility.cs
+++ b/Packages/com.llealloo.audiolink/Editor/Scripts/AudioLinkShaderCompatabilityUtility.cs
@@ -7,8 +7,8 @@ namespace VRCAudioLink.Editor
 {
     public class AudioLinkShaderCompatabilityUtility
     {
-        private const string OldPath = "Assets/AudioLink/Shaders/AudioLink.cginc";
-        private const string NewPath = "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc";
+        private const string OldAbsolutePath = "Assets/AudioLink/Shaders/AudioLink.cginc";
+        private const string NewAbsolutePath = "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc";
         private const string MenuItemPath = "AudioLink/Upgrade AudioLink shaders";
 
         private const string DialogText =

--- a/Packages/com.llealloo.audiolink/Editor/Scripts/AudioLinkShaderCompatabilityUtility.cs
+++ b/Packages/com.llealloo.audiolink/Editor/Scripts/AudioLinkShaderCompatabilityUtility.cs
@@ -88,9 +88,9 @@ namespace VRCAudioLink.Editor
         {
             string[] shaderSource = File.ReadAllLines(path);
             bool shouldWrite = false;
-            for (int index = 0; index < shaderSource.Length; index++)
+            for (int i = 0; i < shaderSource.Length; i++)
             {
-                string line = shaderSource[index];
+                string line = shaderSource[i];
                 if (line.Contains(OldAbsolutePath))
                 {
                     line = line.Replace(OldAbsolutePath, NewAbsolutePath);
@@ -99,7 +99,7 @@ namespace VRCAudioLink.Editor
                         line = line.Replace("./Packages", "Packages");
                         line = line.Replace("/Packages", "Packages");
                     }
-                    shaderSource[index] = line;
+                    shaderSource[i] = line;
                     shouldWrite = true;
                 }
                 else if (!line.Contains(NewAbsolutePath) && line.Contains("AudioLink.cginc"))
@@ -108,7 +108,9 @@ namespace VRCAudioLink.Editor
                     string fullPath = Path.GetFullPath(Path.GetDirectoryName(path) + '/' + trimmedLine.TrimStart('/')).Replace('\\', '/');
                     if (fullPath.EndsWith(OldAbsolutePath))
                     {
-                        shaderSource[index] = "#include \"" + NewAbsolutePath + "\"";
+                        int index = line.IndexOf("#include");
+                        string whitespace = line.Remove(index, line.Length - index);
+                        shaderSource[i] = whitespace + "#include \"" + NewAbsolutePath + "\"";
                         shouldWrite = true;
                     }
                 }

--- a/Packages/com.llealloo.audiolink/Editor/Scripts/AudioLinkShaderCompatabilityUtility.cs
+++ b/Packages/com.llealloo.audiolink/Editor/Scripts/AudioLinkShaderCompatabilityUtility.cs
@@ -12,7 +12,7 @@ namespace VRCAudioLink.Editor
         private const string MenuItemPath = "AudioLink/Upgrade AudioLink shaders";
 
         private const string DialogText =
-            "Do you want to check all shaders in this project for AudioLink 0.3.x compatibility and update them if necessary? This is useful for upgrading projects using AudioLink 0.2.x or below.?"
+            "Do you want to check all shaders in this project for AudioLink 0.3.x compatibility and update them if necessary? This is useful for upgrading projects using AudioLink 0.2.x or below."
             + "\n" + "\n" +
             "If you choose 'Go Ahead', shader files in this project which include 'AudioLink.cginc' will be edited to use the new path introduced by AudioLink 0.3.x. Shaders which already use the new path will be unaffected. You should make a backup before proceeding."
             + "\n" + "\n" +

--- a/Packages/com.llealloo.audiolink/Editor/Scripts/AudioLinkShaderCompatabilityUtility.cs
+++ b/Packages/com.llealloo.audiolink/Editor/Scripts/AudioLinkShaderCompatabilityUtility.cs
@@ -9,16 +9,16 @@ namespace VRCAudioLink.Editor
     {
         private const string OldAbsolutePath = "Assets/AudioLink/Shaders/AudioLink.cginc";
         private const string NewAbsolutePath = "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc";
-        private const string MenuItemPath = "AudioLink/Upgrade AudioLink shaders";
+        private const string MenuItemPath = "AudioLink/Update AudioLink compatible shaders";
 
         private const string DialogText =
             "Do you want to check all shaders in this project for AudioLink 0.3.x compatibility and update them if necessary? This is useful for upgrading projects using AudioLink 0.2.x or below."
             + "\n" + "\n" +
-            "If you choose 'Go Ahead', shader files in this project which include 'AudioLink.cginc' will be edited to use the new path introduced by AudioLink 0.3.x. Shaders which already use the new path will be unaffected. You should make a backup before proceeding."
+            "If you choose 'Go Ahead', shader files in this project which include references to 'Assets/AudioLink/Shaders/AudioLink.cginc' will be edited to use the new path introduced by AudioLink 0.3.x. Shaders which already use the new or custom path will be unaffected. You should make a backup before proceeding."
             + "\n" + "\n" +
             "(You can always run this utility manually via the " + MenuItemPath + " menu command)";
 
-        private const string DialogTitle = "AudioLink Shader Compatibility Utility";
+        private const string DialogTitle = "Upgrade AudioLink compatible shaders";
         private const string DialogOkButton = "I Made a Backup, Go Ahead!";
         private const string DialogCancelButton = "No Thanks";
 

--- a/Packages/com.llealloo.audiolink/Editor/Scripts/AudioLinkShaderCompatabilityUtility.cs.meta
+++ b/Packages/com.llealloo.audiolink/Editor/Scripts/AudioLinkShaderCompatabilityUtility.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b29e871baf7e4040947743089b525636
+timeCreated: 1661945529


### PR DESCRIPTION
A utility to upgrade absolute shader paths pointing to the old path to point to the new path