### PR TITLE
Updated Filtered AL Docs

### DIFF
--- a/Docs/README.md
+++ b/Docs/README.md
@@ -339,7 +339,7 @@ The red value is the acutal autocorrelator value, centered around the 0th bin. T
 
 This is the most recent 4 Band AudioLink value, but heavily smoothed. This allows you to avoid potentially unwanted jerkiness/strobing when the 4 Band values are changing quickly.
 
-There are 16 smoothing levels offered, starting with the most smoothed at `Y: 0`.  The least smoothed is at `Y: 15`.
+There are 16 smoothing levels offered, starting with the most smoothed at `X: 0`.  The least smoothed is at `X: 15`.
 
 You can get a level 10 smoothed Bass value like this:
 

--- a/Docs/README.md
+++ b/Docs/README.md
@@ -337,7 +337,7 @@ The red value is the acutal autocorrelator value, centered around the 0th bin. T
 
 ### `ALPASS_FILTEREDAUDIOLINK`
 
-This is the most recent 4 Band AudioLink value, but heavily smoothed.  This feature was added in version 2.5.
+This is the most recent 4 Band AudioLink value, but heavily smoothed. This allows you to avoid potentially unwanted jerkiness/strobing when the 4 Band values are changing quickly.
 
 There are 16 smoothing levels offered, starting with the most smoothed at `Y: 0`.  The least smoothed is at `Y: 15`.
 
@@ -346,6 +346,8 @@ You can get a level 10 smoothed Bass value like this:
 ```hlsl
     return AudioLinkData( ALPASS_FILTEREDAUDIOLINK + int2(10, 0) ).rrrr;
 ```
+
+This feature was added in version 2.5.
 
 ### `ALPASS_CHRONOTENSITY`
 

--- a/Docs/README.md
+++ b/Docs/README.md
@@ -337,7 +337,15 @@ The red value is the acutal autocorrelator value, centered around the 0th bin. T
 
 ### `ALPASS_FILTEREDAUDIOLINK`
 
-This is just the initial audiolink values, but very heavily filtered, so they move very smoothly.  This feature was added in version 2.5.
+This is the most recent 4 Band AudioLink value, but heavily smoothed.  This feature was added in version 2.5.
+
+There are 16 smoothing levels offered, starting with the most smoothed at `Y: 0`.  The least smoothed is at `Y: 15`.
+
+You can get a level 10 smoothed Bass value like this:
+
+```hlsl
+    return AudioLinkData( ALPASS_FILTEREDAUDIOLINK + int2(10, 0) ).rrrr;
+```
 
 ### `ALPASS_CHRONOTENSITY`
 


### PR DESCRIPTION
There was some discussion in Shader discord, and I think the docs might use a little bit of a bigger explanation of the feature, as it is really useful!

## Current Docs

### `ALPASS_FILTEREDAUDIOLINK`

This is just the initial audiolink values, but very heavily filtered, so they move very smoothly. This feature was added in version 2.5.

## New Docs

### `ALPASS_FILTEREDAUDIOLINK`

This is the most recent 4 Band AudioLink value, but heavily smoothed. This allows you to avoid potentially unwanted jerkiness/strobing when the 4 Band values are changing quickly.

There are 16 smoothing levels offered, starting with the most smoothed at `X: 0`.  The least smoothed is at `X: 15`.

You can get a level 10 smoothed Bass value like this:

```hlsl
    return AudioLinkData( ALPASS_FILTEREDAUDIOLINK + int2(10, 0) ).rrrr;
```

This feature was added in version 2.5.