### PR TITLE
Yt-dlp: UI/functionality tweaks

### DIFF
--- a/Packages/com.llealloo.audiolink/Runtime/Scripts/YtdlpPlayer.cs
+++ b/Packages/com.llealloo.audiolink/Runtime/Scripts/YtdlpPlayer.cs
@@ -21,6 +21,9 @@ namespace AudioLink
         public string ytdlpURL = "https://www.youtube.com/watch?v=SFTcZ1GXOCQ";
         Request _currentRequest = null;
 
+        [SerializeField]
+        public bool showVideoPreviewInComponent = false;
+
         [SerializeReference]
         public VideoPlayer VideoPlayer = null;
 
@@ -359,6 +362,20 @@ namespace AudioLink
             using (new EditorGUI.DisabledScope(EditorApplication.isPlaying || videoPlayerOnThisObject))
             {
                 _ytdlpPlayer.VideoPlayer = (VideoPlayer)EditorGUILayout.ObjectField(new GUIContent("  VideoPlayer", EditorGUIUtility.IconContent("d_Profiler.Video").image), _ytdlpPlayer.VideoPlayer, typeof(VideoPlayer), allowSceneObjects: true);
+            }
+
+            // Video preview
+            using (new EditorGUI.DisabledScope(!available || !hasVideoPlayer))
+            {
+                _ytdlpPlayer.showVideoPreviewInComponent = EditorGUILayout.Toggle(new GUIContent("  Show Video Preview", EditorGUIUtility.IconContent("d_ViewToolOrbit On").image), _ytdlpPlayer.showVideoPreviewInComponent);
+
+                if (_ytdlpPlayer.showVideoPreviewInComponent && available && hasVideoPlayer && _ytdlpPlayer.VideoPlayer.texture != null)
+                {
+                    // Draw video preview with the same aspect ratio as the video
+                    float aspectRatio = (float)_ytdlpPlayer.VideoPlayer.texture.width / _ytdlpPlayer.VideoPlayer.texture.height;
+                    Rect previewRect = GUILayoutUtility.GetAspectRect(aspectRatio, GUILayout.MaxHeight(100));
+                    EditorGUI.DrawPreviewTexture(previewRect, _ytdlpPlayer.VideoPlayer.texture, null, ScaleMode.StretchToFill);
+                }
             }
 
             if (!available)

--- a/Packages/com.llealloo.audiolink/Runtime/Scripts/YtdlpPlayer.cs
+++ b/Packages/com.llealloo.audiolink/Runtime/Scripts/YtdlpPlayer.cs
@@ -27,6 +27,21 @@ namespace AudioLink
         [SerializeReference]
         public VideoPlayer VideoPlayer = null;
 
+        [SerializeField]
+        public Resolution resolution = Resolution._720p;
+
+        public enum Resolution
+        {
+            [InspectorName("144p")] _144p = 144,
+            [InspectorName("240p")] _240p = 240,
+            [InspectorName("360p")] _360p = 360,
+            [InspectorName("480p")] _480p = 480,
+            [InspectorName("720p")] _720p = 720,
+            [InspectorName("1080p")] _1080p = 1080,
+            [InspectorName("1440p")] _1440p = 1440,
+            [InspectorName("2160p")] _2160p = 2160,
+        }
+
         void OnEnable()
         {
             RequestPlay();
@@ -34,7 +49,7 @@ namespace AudioLink
 
         public void RequestPlay()
         {
-            _currentRequest = YtdlpURLResolver.Resolve(ytdlpURL);
+            _currentRequest = YtdlpURLResolver.Resolve(ytdlpURL, (int)resolution);
         }
 
         void Update()
@@ -174,9 +189,8 @@ namespace AudioLink
             }
         }
 
-        public static Request Resolve(string url)
+        public static Request Resolve(string url, int resolution = 720)
         {
-            const int resolution = 720;
             if (!_ytdlpFound)
             {
                 LocateYtdlp();
@@ -281,7 +295,11 @@ namespace AudioLink
 
             using (new EditorGUI.DisabledScope(!available))
             {
-                _ytdlpPlayer.ytdlpURL = EditorGUILayout.TextField(new GUIContent(" Video URL", EditorGUIUtility.IconContent("CloudConnect").image), _ytdlpPlayer.ytdlpURL);
+                using (new EditorGUILayout.HorizontalScope())
+                {
+                    _ytdlpPlayer.ytdlpURL = EditorGUILayout.TextField(new GUIContent(" Video URL", EditorGUIUtility.IconContent("CloudConnect").image), _ytdlpPlayer.ytdlpURL);
+                    _ytdlpPlayer.resolution = (YtdlpPlayer.Resolution)EditorGUILayout.EnumPopup(_ytdlpPlayer.resolution, GUILayout.Width(70));
+                }
 
                 using (new EditorGUI.DisabledScope(!hasVideoPlayer || !EditorApplication.isPlaying))
                 {

--- a/Packages/com.llealloo.audiolink/Runtime/Scripts/YtdlpPlayer.cs
+++ b/Packages/com.llealloo.audiolink/Runtime/Scripts/YtdlpPlayer.cs
@@ -327,12 +327,15 @@ namespace AudioLink
                         // Timestamp input
                         EditorGUI.BeginChangeCheck();
                         double time = hasVideoPlayer ? _ytdlpPlayer.VideoPlayer.time : 0;
-                        string currentTimestamp = " " + _ytdlpPlayer.FormattedTimestamp(time);
+                        string currentTimestamp = _ytdlpPlayer.FormattedTimestamp(time, videoLength);
                         string seekTimestamp = EditorGUILayout.DelayedTextField(currentTimestamp, GUILayout.MaxWidth(8 * currentTimestamp.Length));
                         if (EditorGUI.EndChangeCheck() && videoLength > 0)
                         {
                             TimeSpan inputTimestamp;
-                            // Add an extra 00: to force TimeSpan to interpret 12:34 as 00:12:34 for proper mm:ss input
+                            // Add extra 00:'s to force TimeSpan.TryParse to interpret times properly
+                            // 22 -> 00:00:22, 2:22 -> 00:02:22, 2:22:22 -> 00:2:22:22
+                            if (seekTimestamp.Length < 5)
+                                seekTimestamp = "00:" + seekTimestamp;
                             if (TimeSpan.TryParse($"00:{seekTimestamp}", out inputTimestamp))
                             {
                                 playbackTime = (float)(inputTimestamp.TotalSeconds / videoLength);

--- a/Packages/com.llealloo.audiolink/Runtime/Scripts/YtdlpPlayer.cs
+++ b/Packages/com.llealloo.audiolink/Runtime/Scripts/YtdlpPlayer.cs
@@ -391,8 +391,8 @@ namespace AudioLink
                 {
                     // Draw video preview with the same aspect ratio as the video
                     float aspectRatio = (float)_ytdlpPlayer.VideoPlayer.texture.width / _ytdlpPlayer.VideoPlayer.texture.height;
-                    Rect previewRect = GUILayoutUtility.GetAspectRect(aspectRatio, GUILayout.MaxHeight(100));
-                    EditorGUI.DrawPreviewTexture(previewRect, _ytdlpPlayer.VideoPlayer.texture, null, ScaleMode.StretchToFill);
+                    Rect previewRect = GUILayoutUtility.GetAspectRect(aspectRatio);
+                    EditorGUI.DrawPreviewTexture(previewRect, _ytdlpPlayer.VideoPlayer.texture, null, ScaleMode.ScaleToFit);
                 }
             }
 

--- a/Packages/com.llealloo.audiolink/Runtime/Scripts/YtdlpPlayer.cs
+++ b/Packages/com.llealloo.audiolink/Runtime/Scripts/YtdlpPlayer.cs
@@ -252,7 +252,7 @@ namespace AudioLink
         {
             _ytdlpPlayer = (YtdlpPlayer)target;
             // If video player is on the same gameobject, assign it automatically
-            if(_ytdlpPlayer.gameObject.GetComponent<VideoPlayer>() != null)
+            if (_ytdlpPlayer.gameObject.GetComponent<VideoPlayer>() != null)
                 _ytdlpPlayer.VideoPlayer = _ytdlpPlayer.gameObject.GetComponent<VideoPlayer>();
         }
 

--- a/Packages/com.llealloo.audiolink/Runtime/Scripts/YtdlpPlayer.cs
+++ b/Packages/com.llealloo.audiolink/Runtime/Scripts/YtdlpPlayer.cs
@@ -32,8 +32,6 @@ namespace AudioLink
 
         public enum Resolution
         {
-            [InspectorName("144p")] _144p = 144,
-            [InspectorName("240p")] _240p = 240,
             [InspectorName("360p")] _360p = 360,
             [InspectorName("480p")] _480p = 480,
             [InspectorName("720p")] _720p = 720,
@@ -297,8 +295,9 @@ namespace AudioLink
             {
                 using (new EditorGUILayout.HorizontalScope())
                 {
-                    _ytdlpPlayer.ytdlpURL = EditorGUILayout.TextField(new GUIContent(" Video URL", EditorGUIUtility.IconContent("CloudConnect").image), _ytdlpPlayer.ytdlpURL);
-                    _ytdlpPlayer.resolution = (YtdlpPlayer.Resolution)EditorGUILayout.EnumPopup(_ytdlpPlayer.resolution, GUILayout.Width(70));
+                    EditorGUILayout.LabelField(new GUIContent(" Video URL", EditorGUIUtility.IconContent("CloudConnect").image), GUILayout.Width(100));
+                    _ytdlpPlayer.ytdlpURL = EditorGUILayout.TextField(_ytdlpPlayer.ytdlpURL);
+                    _ytdlpPlayer.resolution = (YtdlpPlayer.Resolution)EditorGUILayout.EnumPopup(_ytdlpPlayer.resolution, GUILayout.Width(65));
                 }
 
                 using (new EditorGUI.DisabledScope(!hasVideoPlayer || !EditorApplication.isPlaying))

--- a/Packages/com.llealloo.audiolink/Runtime/Scripts/YtdlpPlayer.cs
+++ b/Packages/com.llealloo.audiolink/Runtime/Scripts/YtdlpPlayer.cs
@@ -278,7 +278,7 @@ namespace AudioLink
 
             using (new EditorGUI.DisabledScope(!available))
             {
-                _ytdlpPlayer.ytdlpURL = EditorGUILayout.DelayedTextField(new GUIContent(" Video URL", EditorGUIUtility.IconContent("CloudConnect").image), _ytdlpPlayer.ytdlpURL);
+                _ytdlpPlayer.ytdlpURL = EditorGUILayout.TextField(new GUIContent(" Video URL", EditorGUIUtility.IconContent("CloudConnect").image), _ytdlpPlayer.ytdlpURL);
 
                 using (new EditorGUI.DisabledScope(!hasVideoPlayer || !EditorApplication.isPlaying))
                 {


### PR DESCRIPTION
Changes:
- Add Resolution selection (from a list of options)
- Expose audiosource volume if available, so it's easy to adjust
- Add play/pause/stop buttons
- Allow seeking while paused
- Video preview
- Make VideoPlayer a serialized reference so it doesn't need to be on the same object