### PR TITLE
Fix theme mode & colors being overwritten by defaults

### DIFF
--- a/Packages/com.llealloo.audiolink/Runtime/Scripts/ThemeColorController.cs
+++ b/Packages/com.llealloo.audiolink/Runtime/Scripts/ThemeColorController.cs
@@ -44,6 +44,7 @@ namespace AudioLink
         public Slider sliderValue;
         public Transform[] customColorLassos;
         public int customColorIndex = 0;
+        private bool initDone = false;
 
         private void Start()
         {
@@ -51,14 +52,34 @@ namespace AudioLink
             localPlayer = Networking.LocalPlayer;
 #endif
 
-            _initCustomThemeColors = new[] {
+            if (audioLink != null)
+            {
+                _initThemeColorMode = audioLink.themeColorMode;
+                _initCustomThemeColors = new Color[4] {
+                        audioLink.customThemeColor0,
+                        audioLink.customThemeColor1,
+                        audioLink.customThemeColor2,
+                        audioLink.customThemeColor3,
+                    };
+                customThemeColors = new Color[4]{
+                        _initCustomThemeColors[0],
+                        _initCustomThemeColors[1],
+                        _initCustomThemeColors[2],
+                        _initCustomThemeColors[3],
+                    };
+            }
+            else
+            {
+                _initThemeColorMode = themeColorDropdown.value;
+                _initCustomThemeColors = new Color[4] {
                     customThemeColors[0],
                     customThemeColors[1],
                     customThemeColors[2],
                     customThemeColors[3],
                 };
+            }
+            initDone = true;
 
-            _initThemeColorMode = themeColorDropdown.value;
             _themeColorMode = _initThemeColorMode;
 
             UpdateGUI();
@@ -152,6 +173,7 @@ namespace AudioLink
 
         public void UpdateAudioLinkThemeColors()
         {
+            if(!initDone) return;
             if (audioLink == null) return;
             audioLink.themeColorMode = _themeColorMode;
             audioLink.customThemeColor0 = customThemeColors[0];


### PR DESCRIPTION
This modification ensures that the theme mode and colors are retrieved from the AudioLink instance at Start.
Currently in `master` and release 0.3.2 they seem to get overridden by the default values at runtime.
This fix was originally developed on release 0.3.2, though I ported it to `master` for the purposes of this pull req. I tested again using master and the included sample project/scene.
I am not an expert with U# so feel free to suggest changes. I fixed this in my own local files and figured I might as well try to make a pull req to make it official.

Issue repo steps:
1. Add audiolink and controller to your scene.
2. Change theme colors and/or mode in the inspector.
3. Either build and test or enter play mode with ClientSim.
4. Observe that the mode dropdown has been set back to ColorChord, and the theme colors have reverted to the default yellow, blue, red, green.

With this fix the theme colors and mode will retain the values set before entering play mode.

Fixes  #281