### PR TITLE
Move the AudioLink menus under the Tools top-level menu

### DIFF
--- a/Packages/com.llealloo.audiolink/Editor/Scripts/AudioLinkAssetManager.cs
+++ b/Packages/com.llealloo.audiolink/Editor/Scripts/AudioLinkAssetManager.cs
@@ -37,7 +37,7 @@ namespace AudioLink.Editor
         }
 
 #if !AUDIOLINK_STANDALONE
-        [MenuItem("AudioLink/Open AudioLink Example Scene")]
+        [MenuItem("Tools/AudioLink/Open AudioLink Example Scene")]
         public static void OpenExampleScene()
         {
             if (EditorSceneManager.SaveCurrentModifiedScenesIfUserWantsTo())
@@ -56,7 +56,7 @@ namespace AudioLink.Editor
         }
 #endif
 
-        [MenuItem("AudioLink/Add AudioLink Prefab to Scene", false)]
+        [MenuItem("Tools/AudioLink/Add AudioLink Prefab to Scene", false)]
         [MenuItem("GameObject/AudioLink/Add AudioLink Prefab to Scene", false, 49)]
         public static void AddAudioLinkToScene()
         {

--- a/Packages/com.llealloo.audiolink/Editor/Scripts/AudioLinkShaderCompatabilityUtility.cs
+++ b/Packages/com.llealloo.audiolink/Editor/Scripts/AudioLinkShaderCompatabilityUtility.cs
@@ -9,7 +9,7 @@ namespace AudioLink.Editor
     {
         private const string OldAbsolutePath = "Assets/AudioLink/Shaders/AudioLink.cginc";
         private const string NewAbsolutePath = "Packages/com.llealloo.audiolink/Runtime/Shaders/AudioLink.cginc";
-        private const string MenuItemPath = "AudioLink/Update AudioLink compatible shaders";
+        private const string MenuItemPath = "Tools/AudioLink/Update AudioLink Compatible Shaders";
 
         private const string DialogText =
             "Do you want to check all shaders in this project for AudioLink 0.3.x compatibility and update them if necessary? This is useful for upgrading projects using AudioLink 0.2.x or below."


### PR DESCRIPTION
Brings audiolink menu in line with other community assets, like protv and ltcgi.