### PR TITLE
Made Controller call AudioLinkEnable/Disable

### DIFF
--- a/Packages/com.llealloo.audiolink/Runtime/Scripts/AudioLink.cs
+++ b/Packages/com.llealloo.audiolink/Runtime/Scripts/AudioLink.cs
@@ -269,6 +269,8 @@ namespace AudioLink
             _Samples1R = PropertyToID("_Samples1R");
             _Samples2R = PropertyToID("_Samples2R");
             _Samples3R = PropertyToID("_Samples3R");
+
+            _IsInitialized = true;
         }
         #endregion
 
@@ -592,7 +594,6 @@ namespace AudioLink
 
         private void OnEnable()
         {
-            InitIDs();
             EnableAudioLink();
         }
 
@@ -735,6 +736,7 @@ namespace AudioLink
 
         public void EnableAudioLink()
         {
+            InitIDs();
             _audioLinkEnabled = true;
             audioRenderTexture.updateMode = CustomRenderTextureUpdateMode.Realtime;
 #if UDONSHARP

--- a/Packages/com.llealloo.audiolink/Runtime/Scripts/AudioLink.cs
+++ b/Packages/com.llealloo.audiolink/Runtime/Scripts/AudioLink.cs
@@ -121,6 +121,8 @@ namespace AudioLink
         [NonSerialized] public Color[] audioData = new Color[AudioLinkWidth * AudioLinkHeight];
         [HideInInspector] public Texture2D audioData2D; // Texture2D reference for hacked Blit, may eventually be depreciated
 
+        private bool _audioLinkEnabled = true;
+
         private float[] _audioFramesL = new float[1023 * 4];
         private float[] _audioFramesR = new float[1023 * 4];
         private float[] _samples = new float[1023];
@@ -428,6 +430,11 @@ namespace AudioLink
 
         private void Update()
         {
+            if (!_audioLinkEnabled)
+            {
+                return;
+            }
+
 #if !UNITY_ANDROID
             if (audioDataToggle)
             {
@@ -557,7 +564,7 @@ namespace AudioLink
 #if UNITY_ANDROID
         void OnPostRender()
         {
-            if (audioDataToggle)
+            if (_audioLinkEnabled && audioDataToggle)
             {
                 audioData2D.ReadPixels(new Rect(0, 0, audioData2D.width, audioData2D.height), 0, 0, false);
                 audioData = audioData2D.GetPixels();
@@ -728,6 +735,7 @@ namespace AudioLink
 
         public void EnableAudioLink()
         {
+            _audioLinkEnabled = true;
             audioRenderTexture.updateMode = CustomRenderTextureUpdateMode.Realtime;
 #if UDONSHARP
             SetGlobalTexture(_AudioTexture, audioRenderTexture);
@@ -738,6 +746,7 @@ namespace AudioLink
 
         public void DisableAudioLink()
         {
+            _audioLinkEnabled = false;
             audioRenderTexture.updateMode = CustomRenderTextureUpdateMode.OnDemand;
 #if UDONSHARP
             SetGlobalTexture(_AudioTexture, null);

--- a/Packages/com.llealloo.audiolink/Runtime/Scripts/AudioLinkController.cs
+++ b/Packages/com.llealloo.audiolink/Runtime/Scripts/AudioLinkController.cs
@@ -242,7 +242,14 @@ namespace AudioLink
             audioLink.UpdateSettings();
 
             // Toggle
-            audioLink.gameObject.SetActive(powerToggle.isOn);
+            if (powerToggle.isOn)
+            {
+                audioLink.EnableAudioLink();
+            }
+            else
+            {
+                audioLink.DisableAudioLink();
+            }
         }
 
         public void ResetSettings()


### PR DESCRIPTION
• Made the AudioLinkController call AudioLinkEnable/Disable instead of toggling the AudioLink GameObject.
• Made readbacks stop if AudioLink is disabled.
• Made InitIDs only initialize IDs when called for the first time.