### PR TITLE
Fixed an error with null reference on VRC exit.

### DIFF
--- a/Packages/com.llealloo.audiolink/Runtime/Scripts/AudioLink.cs
+++ b/Packages/com.llealloo.audiolink/Runtime/Scripts/AudioLink.cs
@@ -738,7 +738,7 @@ namespace AudioLink
         public void DisableAudioLink()
         {
             _audioLinkEnabled = false;
-            audioRenderTexture.updateMode = CustomRenderTextureUpdateMode.OnDemand;
+            if (audioRenderTexture != null) { audioRenderTexture.updateMode = CustomRenderTextureUpdateMode.OnDemand; }
 #if UDONSHARP
             SetGlobalTexture(_AudioTexture, null);
 #else


### PR DESCRIPTION
I noticed that whenever* i exit VRC while on my map with AudioLink, while i have that map's project open**, i get an error in the console:
![image](https://github.com/llealloo/vrc-udon-audio-link/assets/19253513/f69b85d0-4d0b-40ff-be7b-0b5277200691)

Apparently during cleaning stuff up the `DisableAudioLink()` method gets called after `audioRenderTexture` becomes null, so an attermpt to set its `updateMode` throws an exception.

This PR fixes it by checking if `audioRenderTexture` is null.

\* sometimes it stops doing that, but works again after project reopen
\** no matter if VRC has been run through the "build and test" or normally through Steam