### PR TITLE
Only process Shaders modifications on Pipeline changes

### DIFF
--- a/Packages/com.llealloo.audiolink/Editor/Scripts/AudioLinkPipelineDetector.cs
+++ b/Packages/com.llealloo.audiolink/Editor/Scripts/AudioLinkPipelineDetector.cs
@@ -21,12 +21,12 @@ namespace AudioLink.Editor
         const string URP = "_UNIVERSAL_RENDER_PIPELINE";
         const string HDRP = "_HIGH_DEFINITION_RENDER_PIPELINE";
 
-        private const string ConvertMenuItemPath = "Tools/AudioLink/Convert Amplify Shaders Pipeline";
+        private const string ConvertMenuItemPath = "Tools/AudioLink/Convert AudioLink Amplify Shaders Pipeline";
         private const string ShaderKeyworkMenuItemPath = "Tools/AudioLink/Apply AudioLink Shader Pipeline Keywords";
 
         private const string ConvertDialogText = "Do you want to convert the AudioLink Amplify shaders to the ";
 
-        private const string ConvertDialogTitle = "Amplify Convert shaders pipeline?";
+        private const string ConvertDialogTitle = "Convert AudioLink Amplify Shaders pipeline?";
         private const string ConvertDialogOkButton = "Convert";
         private const string ConvertDialogCancelButton = "Cancel";
 

--- a/Packages/com.llealloo.audiolink/Editor/Scripts/AudioLinkPipelineDetector.cs
+++ b/Packages/com.llealloo.audiolink/Editor/Scripts/AudioLinkPipelineDetector.cs
@@ -2,6 +2,8 @@ using UnityEngine;
 using UnityEditor;
 using UnityEditor.Build;
 using UnityEditor.Build.Reporting;
+using UnityEngine.Rendering;
+using System.Text.RegularExpressions;
 
 namespace AudioLink.Editor
 {
@@ -14,20 +16,63 @@ namespace AudioLink.Editor
             "AudioLink/Surface"
         };
 
+        const string AUDIOLINK_PIPELINE_FILE = ".audiolink_pipeline";
+        private const string AmplifyAbsoluteDir = "Packages/com.llealloo.audiolink/Runtime/Shaders/Amplify/Shaders";
         const string URP = "_UNIVERSAL_RENDER_PIPELINE";
         const string HDRP = "_HIGH_DEFINITION_RENDER_PIPELINE";
+
+        private const string ConvertMenuItemPath = "Tools/AudioLink/Convert Amplify Shaders Pipeline";
+        private const string ShaderKeyworkMenuItemPath = "Tools/AudioLink/Apply AudioLink Shader Pipeline Keywords";
+
+        private const string ConvertDialogText = "Do you want to convert the AudioLink Amplify shaders to the ";
+
+        private const string ConvertDialogTitle = "Amplify Convert shaders pipeline?";
+        private const string ConvertDialogOkButton = "Convert";
+        private const string ConvertDialogCancelButton = "Cancel";
 
         [InitializeOnLoadMethod]
         private static void InitializeOnLoad()
         {
-            EditorApplication.delayCall += SetShaderKeywords;
+            EditorApplication.delayCall += CheckHasPipelineChanged;
         }
 
         public void OnPreprocessBuild(BuildReport report)
         {
-            SetShaderKeywords();
+            CheckHasPipelineChanged();
         }
 
+        private static void CheckHasPipelineChanged()
+        {
+            if (HasPipelineChanged())
+            {
+                AskConvertShaderFiles();
+                SetShaderKeywords();
+            }
+        }
+
+        public static bool HasPipelineChanged()
+        {
+            bool pipelineChanged = true;
+            string currentPipeline = "UnityEngine.Rendering.Builtin.BuiltinRenderPipelineAsset";
+
+            if (GraphicsSettings.currentRenderPipeline != null)
+                currentPipeline = GraphicsSettings.currentRenderPipeline.GetType().ToString();
+
+            if (System.IO.File.Exists(AUDIOLINK_PIPELINE_FILE))
+            {
+                string lastPipeline = System.IO.File.ReadAllText(AUDIOLINK_PIPELINE_FILE).Trim();
+
+                if (lastPipeline == currentPipeline)
+                    pipelineChanged = false;
+            }
+
+            if (pipelineChanged)
+                System.IO.File.WriteAllText(AUDIOLINK_PIPELINE_FILE, currentPipeline);
+
+            return pipelineChanged;
+        }
+
+        [MenuItem(ShaderKeyworkMenuItemPath)]
         private static void SetShaderKeywords()
         {
             // ReSharper disable ConditionIsAlwaysTrueOrFalse
@@ -83,6 +128,92 @@ namespace AudioLink.Editor
             }
 
             return false;
+        }
+
+        private static string SetLightModeTag(string text, string from, string to)
+        {
+            return new Regex($"\"LightMode\"\\s*=\\s*\"{from}\"").Replace(text, $"\"LightMode\"=\"{to}\"");
+        }
+
+        [MenuItem(ConvertMenuItemPath)]
+        private static void AskConvertShaderFiles()
+        {
+            string renderPipelineName = "BuiltinRenderPipelineAsset";
+
+            if (GraphicsSettings.currentRenderPipeline != null)
+            {
+                renderPipelineName = GraphicsSettings.currentRenderPipeline.GetType().ToString();
+                renderPipelineName = renderPipelineName.Substring(renderPipelineName.LastIndexOf(".") + 1);
+            }
+
+            if (EditorUtility.DisplayDialog(ConvertDialogTitle, ConvertDialogText + renderPipelineName + "?", ConvertDialogOkButton, ConvertDialogCancelButton))
+                ConvertShaderFiles();
+        }
+
+        public static void ConvertShaderFiles()
+        {
+            ShaderInfo[] shaders = ShaderUtil.GetAllShaderInfo();
+
+            foreach (ShaderInfo shaderinfo in shaders)
+            {
+                Shader shader = Shader.Find(shaderinfo.name);
+                string path = AssetDatabase.GetAssetPath(shader);
+                // we want to only affect the Amplify shaders here, so we check the Path prefix
+                if (path.StartsWith(AmplifyAbsoluteDir))
+                {
+#if URP_AVAILABLE || HDRP_AVAILABLE
+                    ReplaceLightModeInFile(path, true);
+#else
+                    ReplaceLightModeInFile(path, false);
+#endif
+                }
+            }
+
+            AssetDatabase.Refresh();
+        }
+
+        private static void ReplaceLightModeInFile(string path, bool srpBased)
+        {
+            string[] shaderSource = System.IO.File.ReadAllLines(path);
+            bool firstPass = true;
+            bool shouldWrite = false;
+            for (int i = 0; i < shaderSource.Length; i++)
+            {
+                string line = shaderSource[i];
+
+                if (line.Contains("\"LightMode\""))
+                {
+                    string initalLine = line;
+                    if (srpBased) // Unity SRP based, URP, HDRP?
+                    {
+                        line = SetLightModeTag(line, "ForwardBase", "UniversalForward");
+                    } else { // Unity BiRP
+                        line = SetLightModeTag(line, "UniversalForward", "ForwardBase");
+                    }
+
+                    shaderSource[i] = line;
+                    if (line != initalLine)
+                        shouldWrite = true;
+                }
+
+                if (line.TrimStart().StartsWith("Pass") && firstPass)
+                {
+                    firstPass = false;
+                    bool hasDepthCurrently = line.Contains("\"LightMode\"=\"DepthOnly\"");
+
+                    if (!hasDepthCurrently && srpBased)
+                    {
+                        shaderSource[i - 1] = "\t\tPass { Tags { \"LightMode\"=\"DepthOnly\"} }";
+                        shouldWrite = true;
+                    } else if (hasDepthCurrently && !srpBased) {
+                        shaderSource[i] = "\t\t";
+                        shouldWrite = true;
+                    }
+                }
+            }
+
+            if (shouldWrite)
+                System.IO.File.WriteAllLines(path, shaderSource);
         }
     }
 }


### PR DESCRIPTION
Checks to see if the Pipeline has changed before automatically modifying Amplify Shaders and Shader Keywords,
Both also have manual Menu entries.

Stores the last used pipeline for the Project in `.audiolink_pipeline` in the Project root folder.

@techanon @pema99 May want to look at this first.

Also moved the Amplify Shader conversion from `AudioLinkShaderCompatabilityUtility.cs` to `AudioLinkPipelineDetector.cs` to make running it with Shader Keyword handling more convenient.