### PR TITLE
HOTFIX: Restore Custom YTDL Location and Custom FFmpeg Location Functionality.

### DIFF
--- a/Packages/com.llealloo.audiolink/Runtime/Scripts/ytdlpPlayer.cs
+++ b/Packages/com.llealloo.audiolink/Runtime/Scripts/ytdlpPlayer.cs
@@ -404,6 +404,9 @@ namespace AudioLink
         {
             _ytdlpFound = false;
 
+            // CRITICAL: Ensure cached prefs are up-to-date. Otherwise, custom path may be ignored after reload.
+            FetchEditorPrefs();
+
             // check for a custom install location
             string customPath = _cachedEditorPrefs.ytdlpPath;
             if (!string.IsNullOrEmpty(customPath))
@@ -446,6 +449,9 @@ namespace AudioLink
         public static void LocateFFmpeg()
         {
             _ffmpegFound = false;
+
+            // CRITICAL: Ensure cached prefs are up-to-date. Otherwise, custom path may be ignored after reload.
+            FetchEditorPrefs();
 
             // check for a custom install location
             string customPath = _cachedEditorPrefs.ffmpegPath;

--- a/Packages/com.llealloo.audiolink/Runtime/Scripts/ytdlpPlayer.cs
+++ b/Packages/com.llealloo.audiolink/Runtime/Scripts/ytdlpPlayer.cs
@@ -2,6 +2,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Video;


### PR DESCRIPTION
### This is a critical fix!

Make sure that `FetchEditorPrefs();` is run when locating Ytdlp and FFmpeg locations. It is very important to make sure this is run. Otherwise, `_cachedEditorPrefs` is completely nullified/empty and the custom location is ignored.