### PR TITLE
Add public wrapper property AudioLinkEnabled

### DIFF
--- a/Packages/com.llealloo.audiolink/Runtime/Scripts/AudioLink.cs
+++ b/Packages/com.llealloo.audiolink/Runtime/Scripts/AudioLink.cs
@@ -124,6 +124,12 @@ namespace AudioLink
 
         private bool _audioLinkEnabled = true;
 
+        public bool AudioLinkEnabled
+        {
+            get => _audioLinkEnabled;
+            set => SetAudioLinkState(value);
+        }
+
         private float[] _audioFramesL = new float[1023 * 4];
         private float[] _audioFramesR = new float[1023 * 4];
         private float[] _samples = new float[1023];


### PR DESCRIPTION
This allows us to set and access AudioLink's enabled state from our own scripts.