### PR TITLE
Document frame counter

### DIFF
--- a/Docs/README.md
+++ b/Docs/README.md
@@ -209,7 +209,7 @@ It contains the following dedicated pixels:
 <table>
 <tr><th>Pixel Offset</th><th>Absolute Pixel</th><th>Description</th><th>Red</th><th>Green</th><th>Blue</th><th>Alpha</th></tr>
 <tr><td>0, 0 </td><td>0, 22</td><td>Version Number and FPS</td><td>Deprecated (returns 3.02f)</td><td>Version Major</td><td>System FPS</td><td>Version Minor</td></tr>
-<tr><td>1, 0 </td><td>1, 22</td><td>AudioLink FPS</td><td></td><td>AudioLink FPS</td><td></td><td></td></tr>
+<tr><td>1, 0 </td><td>1, 22</td><td>AudioLink FPS</td><td>Frame Count</td><td>Internal</td><td>Internal</td><td>Internal</td></tr>
 <tr><td>2, 0 </td><td>2, 22</td><td>Milliseconds Since Instance Start</td><td colspan=4><pre>AudioLinkDecodeDataAs[UInt/Seconds]( ALPASS_GENERALVU_INSTANCE_TIME )</pre></td></tr>
 <tr><td>3, 0 </td><td>3, 22</td><td>Milliseconds Since 12:00 AM Local Time</td><td colspan=4><pre>AudioLinkDecodeDataAs[UInt/Seconds]( ALPASS_GENERALVU_LOCAL_TIME )</pre></td></tr>
 <tr><td>4, 0 </td><td>4, 22</td><td>Milliseconds In Network Time</td><td colspan=4><pre>AudioLinkDecodeDataAs[UInt/Seconds]( ALPASS_GENERALVU_LOCAL_TIME )</pre></td></tr>


### PR DESCRIPTION
Audiolink's frame counter is useful for certain shaders, s.a. quasi-monte carlo fog simulations. It would benefit community shader developers for this to be documented.

I marked the other three fields as "Internal" (similar to the "Internal Timing Tracking" used in the same table) because the semantics are too nuanced to easily capture.