### PR TITLE
fix: re-publish _AudioTexture after render mode change

### DIFF
--- a/Packages/com.llealloo.audiolink/Runtime/AudioLink.asmdef
+++ b/Packages/com.llealloo.audiolink/Runtime/AudioLink.asmdef
@@ -4,7 +4,8 @@
     "references": [
         "UdonSharp.Runtime",
         "UdonSharp.Lib",
-        "VRC.Udon"
+        "VRC.Udon",
+        "Basis Framework"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Packages/com.llealloo.audiolink/Runtime/Scripts/AudioLink.cs
+++ b/Packages/com.llealloo.audiolink/Runtime/Scripts/AudioLink.cs
@@ -717,12 +717,27 @@ namespace AudioLink
         private void OnEnable()
         {
             EnableAudioLink();
+#if BASIS_FRAMEWORK_EXISTS
+            Basis.Scripts.Device_Management.BasisDeviceManagement.OnBootModeChanged
+                += OnBasisBootModeChanged;
+#endif
         }
 
         private void OnDisable()
         {
+#if BASIS_FRAMEWORK_EXISTS
+            Basis.Scripts.Device_Management.BasisDeviceManagement.OnBootModeChanged
+                -= OnBasisBootModeChanged;
+#endif
             DisableAudioLink();
         }
+
+#if BASIS_FRAMEWORK_EXISTS
+        private void OnBasisBootModeChanged(string mode)
+        {
+            if (_audioLinkEnabled) SetAudioLinkGlobalTexture();
+        }
+#endif
 
         public void UpdateSettings()
         {


### PR DESCRIPTION
### Summary

Subscribes AudioLink to `BasisDeviceManagement.OnBootModeChanged` (which already exists in Basis Framework) so `_AudioTexture` gets re-published after Basis switches render modes (Desktop ↔ OpenVR/OpenXR). Without this, the global binding gets wiped by the XR loader cycle and stays `null` for downstream consumers (custom URP passes, shaders that resolve the texture by global lookup) until something runs `SetAudioLinkGlobalTexture` again.

Closes #365

### What changes

- `Runtime/Scripts/AudioLink.cs` — subscribes to `BasisDeviceManagement.OnBootModeChanged` in `OnEnable`, unsubscribes in `OnDisable`, handler calls `SetAudioLinkGlobalTexture` while `_audioLinkEnabled` is true.
- `Runtime/AudioLink.asmdef` — adds `Basis Framework` to references so the Basis types are visible to the compiler when Basis is present.

All Basis-specific code is gated behind `BASIS_FRAMEWORK_EXISTS`, so projects without Basis compile this code out entirely. The asmdef reference to `Basis Framework` produces a benign warning in non-Basis projects (Unity tolerates missing asmdef references with "Reference to non-existent assembly" warnings; it doesn't fail compilation).

### Scope

This PR addresses only the Basis-specific integration. It does **not** include:

- Dropping the `#if UNITY_EDITOR` gate on the existing `CacheAudioTarget` re-check (lines 685–690).
- A host-agnostic per-frame republish via `LateUpdate` or `RenderPipelineManager.beginContextRendering`.

Either or both would complement this PR for hosts that don't expose a render-mode-changed event.

### Testing

Tested in a Unity 6000.4.3f1 + URP 17 + Basis Framework + Oculus Quest Pro (OpenVR/SteamVR) setup:

- **Before**: switching from Desktop to OpenVR wipes the global binding. Downstream consumers (a custom URP realtime light pass) freeze on initial state because `Shader.GetGlobalTexture("_AudioTexture")` returns `null` from the first frame after the switch onward.
- **After**: switching modes re-publishes the global. Downstream consumers continue functioning normally with audio reactivity intact.

Not yet tested in player builds (Editor playmode only), and not tested in non-Basis VR projects — the change is gated behind `BASIS_FRAMEWORK_EXISTS`, so non-Basis projects compile to current `master` behaviour.

### Notes

`BASIS_FRAMEWORK_EXISTS` is provided by Basis Framework itself; projects with Basis installed get the define automatically, and projects without it stay on the unchanged code path.